### PR TITLE
Removed the "instance_dir" argument when building scikit-decide domains

### DIFF
--- a/evaluate_instance.py
+++ b/evaluate_instance.py
@@ -132,7 +132,16 @@ if __name__ == "__main__":
         "--alpha",
         dest="alpha",
         help="configure the alpha value for the score function",
-        default=0.1,
+        default=0.7,
+        type=float,
+        required=False,
+    )
+
+    parser.add_argument(
+        "--beta",
+        dest="beta",
+        help="configure the beta value for the score function",
+        default=0.0004,
         type=float,
         required=False,
     )
@@ -205,7 +214,8 @@ if __name__ == "__main__":
                               time_limit=args.time_limit,
                               planner=planner,
                               seed=gen_params['config'].seed,
-                              alpha=args.alpha)
+                              alpha=args.alpha,
+                              beta=args.beta)
     else:
         evaluator = DeterministicEvaluator(prb=inst,
                               problem_name=problem_name,
@@ -213,7 +223,8 @@ if __name__ == "__main__":
                               max_steps=args.max_simulation_steps, # TODO change this
                               time_limit=args.time_limit,
                               planner=planner,
-                              alpha=args.alpha)
+                              alpha=args.alpha,
+                              beta=args.beta)
 
     # Setup the evaluator
     evaluator.setup()

--- a/evaluate_instance.py
+++ b/evaluate_instance.py
@@ -5,12 +5,12 @@ import os
 
 import argparse
 import sys
-import uuid
+# import uuid
 
 # TODO remove these once they have been encapsulated
-from skd_domains.skd_pddl_domain import SkdPDDLDomain
-from skd_domains.skd_ppddl_domain import SkdPPDDLDomain
-from skd_domains.skd_spddl_domain import SkdSPDDLDomain
+# from skd_domains.skd_pddl_domain import SkdPDDLDomain
+# from skd_domains.skd_ppddl_domain import SkdPPDDLDomain
+# from skd_domains.skd_spddl_domain import SkdSPDDLDomain
 
 # from generate_instance import ProbConfig, main as encode_json
 from beluga_lib.beluga_problem import BelugaProblemDecoder
@@ -21,6 +21,7 @@ from evaluation.planner_examples import FixedPlanDeterministicPlanner
 from evaluation.planner_examples import LazyAstarDeterministicPlanner, LazyAstarProbabilisticPlanner
 
 def build_planner(args):
+    planner = None
     if args.det_plan_file is not None:
         planner = FixedPlanDeterministicPlanner(args.det_plan_file)
     elif args.probabilistic_evaluation:

--- a/evaluate_instance.py
+++ b/evaluate_instance.py
@@ -5,14 +5,7 @@ import os
 
 import argparse
 import sys
-# import uuid
 
-# TODO remove these once they have been encapsulated
-# from skd_domains.skd_pddl_domain import SkdPDDLDomain
-# from skd_domains.skd_ppddl_domain import SkdPPDDLDomain
-# from skd_domains.skd_spddl_domain import SkdSPDDLDomain
-
-# from generate_instance import ProbConfig, main as encode_json
 from beluga_lib.beluga_problem import BelugaProblemDecoder
 import generate_instance as bgi
 from evaluation.evaluators import ProbabilisticEvaluator, DeterministicEvaluator
@@ -60,15 +53,6 @@ if __name__ == "__main__":
 
     # Parse the instance generation parameters
     bgi._setup_argument_parser(parser)
-
-    # # Specific parameters for this script
-    # parser.add_argument(
-    #     "-n",
-    #     "--numeric",
-    #     dest="numeric",
-    #     help="numeric encoding, otherwise classic encoding",
-    #     action="store_true",
-    # )
 
     parser.add_argument(
         "-ms",
@@ -163,13 +147,6 @@ if __name__ == "__main__":
             sys.stderr.write(f'The `prebuilt-plan` option is incompatible with the probabilistic evaluation')
         if args.input_problem is None:
             sys.stderr.write(f'When using the `prebuilt-plan` option, an input problem must be specified')
-
-    # # Build directories for the temporary files, if needed
-    # if gen_params['problem_folder'] is None:
-    #     gen_params['problem_folder'] = "__tmp_out_" + uuid.uuid4().hex + "__"
-    #     # os.makedirs(gen_params['problem_folder'])
-    # if not os.path.exists(gen_params['problem_folder']):
-    #     os.makedirs(gen_params['problem_folder'])
 
     # ========================================================================
     # Generate a problem instance

--- a/evaluation/evaluators.py
+++ b/evaluation/evaluators.py
@@ -184,7 +184,9 @@ def compute_score_dict(outcome : SingleSimulationOutcome,
     if outcome.free_racks is not None:
         C = len(prb.racks) / (1 + outcome.free_racks)
     value = A * np.exp(- alpha * B - beta * C)
-    res = {'value': value, 'alpha': alpha, 'beta': beta}
+    # res = {'value': value, 'alpha': alpha, 'beta': beta}
+    res = {'value': value, 'alpha': alpha, 'beta': beta,
+           'A': A, 'B': B, 'C': C}
     return res
 
 # ============================================================================

--- a/evaluation/evaluators.py
+++ b/evaluation/evaluators.py
@@ -488,7 +488,6 @@ class DeterministicEvaluator:
 
     def setup(self):
         # Build an SKD domain
-        # self.domain = SkdPDDLDomain(self.prb, self.problem_name, self.problem_folder, classic=False)
         self.domain = SkdPDDLDomain(self.prb, self.problem_name, classic=False)
         # Build an support object
         self.es = EvaluationSupport(self.prb, self.domain)
@@ -684,11 +683,6 @@ class ProbabilisticEvaluator:
 
     def setup(self):
         # Build an SKD domain
-        # self.domain = SkdSPDDLDomain(self.prb,
-        #                              self.problem_name,
-        #                              self.problem_folder,
-        #                              seed=self.seed,
-        #                              classic=False)
         self.domain = SkdSPDDLDomain(self.prb,
                                      self.problem_name,
                                      seed=self.seed,

--- a/evaluation/evaluators.py
+++ b/evaluation/evaluators.py
@@ -124,7 +124,7 @@ class MultipleSimulationOutcome:
 
     def _avg_score_dict(self):
         keys = self.individual_outcomes[0].score.keys()
-        return {k:np.mean([o.score[k] for o in self.individual_outcomes]) for k in keys}
+        return {k:np.nanmean([o.score[k] for o in self.individual_outcomes]) for k in keys}
 
     def to_json_obj(self):
         return {
@@ -465,8 +465,8 @@ class DeterministicEvaluator:
                  planner : DeterministicPlannerAPI,
                  max_steps : int = None,
                  time_limit : int = None,
-                 alpha : float = 0.1,
-                 beta : float = 0.1
+                 alpha : float = 0.7,
+                 beta : float = 0.0004
                  ):
         # Check arguments
         if max_steps is not None and max_steps <= 0:
@@ -512,7 +512,7 @@ class DeterministicEvaluator:
         elapsed_time += time.time() - tstart
 
         # Handle the case where no plan has been built
-        no_plan = (plan is None)
+        no_plan = (plan is None or len(plan.actions) == 0)
         timeout = (self.time_limit is not None and elapsed_time > self.time_limit)
         if no_plan or timeout:
             msg = 'No plan was produced' if no_plan else 'Plan not accepted (time limit reached)'
@@ -526,7 +526,7 @@ class DeterministicEvaluator:
                                               invalid_plan=False,
                                               time_limit_reached=timeout,
                                               step_limit_reached=False,
-                                              free_racks=0,
+                                              free_racks=None,
                                               prb=self.prb,
                                               alpha=self.alpha,
                                               beta=self.beta)
@@ -656,8 +656,8 @@ class ProbabilisticEvaluator:
                  max_steps : int = None,
                  time_limit : int = None,
                  seed : int = None,
-                 alpha : float = 0.1,
-                 beta : float = 0.1
+                 alpha : float = 0.7,
+                 beta : float = 0.0004
                  ):
         # Check arguments
         if nsamples <= 0:

--- a/evaluation/evaluators.py
+++ b/evaluation/evaluators.py
@@ -488,7 +488,8 @@ class DeterministicEvaluator:
 
     def setup(self):
         # Build an SKD domain
-        self.domain = SkdPDDLDomain(self.prb, self.problem_name, self.problem_folder, classic=False)
+        # self.domain = SkdPDDLDomain(self.prb, self.problem_name, self.problem_folder, classic=False)
+        self.domain = SkdPDDLDomain(self.prb, self.problem_name, classic=False)
         # Build an support object
         self.es = EvaluationSupport(self.prb, self.domain)
         self.es.refresh_cache()
@@ -683,9 +684,13 @@ class ProbabilisticEvaluator:
 
     def setup(self):
         # Build an SKD domain
+        # self.domain = SkdSPDDLDomain(self.prb,
+        #                              self.problem_name,
+        #                              self.problem_folder,
+        #                              seed=self.seed,
+        #                              classic=False)
         self.domain = SkdSPDDLDomain(self.prb,
                                      self.problem_name,
-                                     self.problem_folder,
                                      seed=self.seed,
                                      classic=False)
         # Build a support object

--- a/evaluation/planner_examples.py
+++ b/evaluation/planner_examples.py
@@ -258,11 +258,6 @@ class LazyAstarProbabilisticPlanner(ProbabilisticPlannerAPI):
             # print(f'>>> solving planning problem at step {metadata.current_step}')
             slv.solve()
             plan = slv.get_plan()
-        # except AssertionError as e: # NOTE Handle a known issue with scikit-decide
-        #     if e.args[0] == 'n (counts) have to be positive':
-        #         return None
-        #     else:
-        #         raise e
 
         # Cleanup
         domain.cleanup()
@@ -296,8 +291,6 @@ class RandomProbabilisticPlanner(ProbabilisticPlannerAPI):
         # Build a SKD domain
         domain = SkdPDDLDomain(self.prb, problem_name='server_side_domain',
                                classic=self.classic, initial_state=state)
-        # domain = SkdPDDLDomain(self.prb, problem_name='server_side_domain',
-        #                        classic=self.classic, initial_state=None)
         action_space = domain.get_action_space()
         observation_space = domain.get_observation_space()
 
@@ -314,13 +307,7 @@ class RandomProbabilisticPlanner(ProbabilisticPlannerAPI):
             return None
 
         # Determine applicable actions
-        # try:
         actions = domain.get_applicable_actions(s)
-        # except AssertionError as e: # NOTE Handle a known issue with scikit-decide
-        #     if e.args[0] == 'n (counts) have to be positive':
-        #         return None
-        #     else:
-        #         raise e
 
         # print('-' * 78)
         # print('PLANNER APPLICABLE ACTIONS')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ scipy==1.14.1
 gymnasium==0.28.1
 discrete-optimization==0.5.0
 plado>=0.1.3
+ray[tune]==2.40.0
+dm-tree==0.1.8
+lz4==4.3.3
+torch==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-scikit-decide[all]==1.0.2
+scikit-decide==1.0.2
 numpy==1.26.4
 scipy==1.14.1
 gymnasium==0.28.1
 discrete-optimization==0.5.0
-plado>=0.1.2
+plado>=0.1.3


### PR DESCRIPTION
The evolution script was passing directory names when building the scikit-decide domain object. This caused issues in parallel computation environments, since there was a chance that temporary files were rewritten before they were used.