### PR TITLE
Fix pddl action conversion for ExampleBelugaGymCompatibleDomain

### DIFF
--- a/generate_solve_rllib_test.py
+++ b/generate_solve_rllib_test.py
@@ -323,7 +323,7 @@ class ExampleBelugaGymCompatibleDomain(BelugaGymCompatibleDomain):
             outcome = self.skd_beluga_domain._state_step(pddl_action)
             outcome.state = self.make_state_array(outcome.state)
             return TransitionOutcome(
-                state=self.make_state_array(self.make_pddl_state(outcome.state)),
+                state=outcome.state,
                 value=Value(reward=exp(-self.nb_steps) if outcome.termination else 0),
                 termination=outcome.termination or self.nb_steps >= self.max_nb_steps,
                 info=outcome.info,

--- a/generate_solve_rllib_test.py
+++ b/generate_solve_rllib_test.py
@@ -264,11 +264,11 @@ class ExampleBelugaGymCompatibleDomain(BelugaGymCompatibleDomain):
                 and restored_state_array[1][atom][-1] >= 0
             ):
                 plado_state.atoms[restored_state_array[1][atom][0]].add(
-                    [
+                    tuple(
                         int(arg)
                         for arg in restored_state_array[1][atom][1:-1]
                         if arg >= 0
-                    ]
+                    )
                 )
         for fluent in range(self.max_nb_atoms_or_fluents):
             if restored_state_array[2][fluent][0] >= 0:
@@ -299,7 +299,7 @@ class ExampleBelugaGymCompatibleDomain(BelugaGymCompatibleDomain):
         return SkdBaseDomain.T_event(
             domain=self.skd_beluga_domain,
             action_id=int(action_array[0]),
-            args=[int(arg) for arg in action_array[1:] if arg >= 0],
+            args=tuple([int(arg) for arg in action_array[1:] if arg >= 0]),
         )
 
     def _state_reset(self) -> BelugaGymCompatibleDomain.T_state:
@@ -323,7 +323,7 @@ class ExampleBelugaGymCompatibleDomain(BelugaGymCompatibleDomain):
             outcome = self.skd_beluga_domain._state_step(pddl_action)
             outcome.state = self.make_state_array(outcome.state)
             return TransitionOutcome(
-                state=self.make_state_array(outcome.state),
+                state=self.make_state_array(self.make_pddl_state(outcome.state)),
                 value=Value(reward=exp(-self.nb_steps) if outcome.termination else 0),
                 termination=outcome.termination or self.nb_steps >= self.max_nb_steps,
                 info=outcome.info,


### PR DESCRIPTION
- Add fix to valid converted pddl from array action not being recognised in `domain.get_applicable_actions(s)`. Make `make_pddl_action` return args as a tuple instead of list.
- Add adjustments to compatibility for state making after action on `ExampleBelugaGymCompatibleDomain`.

### Description of the problem
![image](https://github.com/user-attachments/assets/c748a42c-549f-4544-9455-a58909315c90)

Here on the variable `a`, I converted an action to pddl from an array form. I then visually verify from the console that a is indeed in the list of applicable actions. Nonetheless, when running the command `domain.get_applicable_actions(s).contains(a)` it returned False, although clearly a is an applicable action on that state.

`domain.get_applicable_actions(s).contains(gym_compatible_domain.make_pddl_action(gym_compatible_domain.make_action_array(domain.get_applicable_actions(s).sample())))`
Here is another command that simply takes an applicable action, and converts it to array and back to pddl. However, this returns False, thus, a problem in the conversion.